### PR TITLE
Add tests

### DIFF
--- a/kefir-test-utils.d.ts
+++ b/kefir-test-utils.d.ts
@@ -31,7 +31,7 @@ export interface Helpers {
   withFakeTime(cb: (tick: (x: number) => void, clock: Clock) => void, reverseSimultaneous?: boolean): void
   logItem<V, E>(event: KEvent<V, E>, current: boolean): Event<V, E>
   watch<V, E>(obs: Observable<V, E>): Watcher<V, E>
-  watchWithTime<V, E>(stream$: Observable<V, E>): EventWithTime<V, E>[]
+  watchWithTime<V, E>(stream$: Observable<V, E>): EventWithTime<V, E>[] & Watcher<V, E>
 }
 
 export interface HelpersFactory {

--- a/kefir-test-utils.test-d.ts
+++ b/kefir-test-utils.test-d.ts
@@ -22,4 +22,4 @@ expectType<void>(
 expectType<Event<string, number>>(logItem({type: 'value', value: 'hello'}, false))
 expectType<Watcher<string, number>>(watch(new Kefir.Stream<string, number>()))
 expectType<EventWithTime<string, any>>([10, value('hello')])
-expectType<EventWithTime<string, number>[]>(watchWithTime(new Kefir.Stream<string, number>()))
+expectType<EventWithTime<string, number>[] & Watcher<string, number>>(watchWithTime(new Kefir.Stream<string, number>()))

--- a/test/kefir-test-utils.spec.js
+++ b/test/kefir-test-utils.spec.js
@@ -4,9 +4,186 @@ import Kefir from 'kefir'
 import createTestUtils from '../src'
 
 describe('kefir-test-utils', () => {
-  describe('factory', () => {
-    it('should return the api', () => {
-      expect(createTestUtils(Kefir)).to.be.an('object')
+  const {
+    END,
+    VALUE,
+    ERROR,
+    send,
+    value,
+    error,
+    end,
+    activate,
+    deactivate,
+    prop,
+    stream,
+    pool,
+    shakeTimers,
+    withFakeTime,
+    logItem,
+    watch,
+    watchWithTime,
+  } = createTestUtils(Kefir)
+
+  describe('observable creators', () => {
+    it('should create a prop', () => {
+      expect(prop()).to.be.instanceof(Kefir.Property)
+    })
+
+    it('should create a stream', () => {
+      expect(stream()).to.be.instanceof(Kefir.Stream)
+    })
+
+    it('should create a pool', () => {
+      expect(pool()).to.be.instanceof(Kefir.Pool)
+    })
+  })
+
+  describe('send', () => {
+    let log, obs
+
+    beforeEach(() => {
+      log = []
+      obs = stream()
+      obs.onAny(val => log.push(val))
+    })
+
+    it('should send a value', () => {
+      send(obs, [value(1)])
+
+      expect(log).to.deep.equal([{type: VALUE, value: 1}])
+    })
+
+    it('should send an error', () => {
+      send(obs, [error(1)])
+
+      expect(log).to.deep.equal([{type: ERROR, value: 1}])
+    })
+
+    it('should send an end', () => {
+      send(obs, [end()])
+
+      expect(log).to.deep.equal([{type: END}])
+    })
+
+    it('should throw if invalid type', () => {
+      expect(() => send(obs, [{type: 'WRONG'}])).to.throw(TypeError)
+    })
+  })
+
+  describe('(de)activate', () => {
+    it('should activate an observable', () => {
+      const obs = activate(stream())
+
+      expect(obs._active).to.equal(true)
+    })
+
+    it('should deactivate an activated observable', () => {
+      const obs = deactivate(activate(stream()))
+
+      expect(obs._active).to.equal(false)
+    })
+  })
+
+  describe('withFakeTime', () => {
+    it('should call callback with tick & clock', () => {
+      let called = false
+
+      withFakeTime((tick, clock) => {
+        called = true
+        expect(tick).to.be.a('function')
+        expect(clock).to.be.an('object')
+
+        tick(10)
+
+        expect(+new Date()).to.equal(1010)
+      })
+
+      expect(called).to.equal(true)
+    })
+
+    it('should call callback with tick & shook clock', () => {
+      let called = false
+
+      withFakeTime((tick, clock) => {
+        called = true
+        expect(tick).to.be.a('function')
+        expect(clock).to.be.an('object')
+
+        let count = 0
+
+        tick(5)
+
+        setTimeout(() => expect(++count).to.equal(2), 5)
+        setTimeout(() => expect(++count).to.equal(1), 5)
+
+        tick(10)
+
+        expect(+new Date()).to.equal(1015)
+        expect(count).to.equal(2)
+      }, true)
+
+      expect(called).to.equal(true)
+    })
+
+    it('should uninstall & rethrow throw errors', () => {
+      const error = new Error('Thrown!')
+      let called = false
+      let errored = false
+      let clock
+
+      try {
+        withFakeTime((_tick, _clock) => {
+          called = true
+          clock = _clock
+
+          throw error
+        })
+      } catch (err) {
+        errored = true
+        expect(error).to.equal(err)
+        expect(clock.setTimeout).not.to.equal(setTimeout)
+      }
+
+      expect(called).to.equal(true)
+      expect(errored).to.equal(true)
+    })
+  })
+
+  describe('watch', () => {
+    it('should log values emitted by stream', () => {
+      const obs = stream()
+      const {log} = watch(obs)
+      send(obs, [value(1), error(2), end()])
+      expect(log).to.deep.equal([value(1), error(2), end()])
+    })
+
+    it('should not log values emitted by stream after unwatch', () => {
+      const obs = stream()
+      const {log, unwatch} = watch(obs)
+      unwatch()
+      send(obs, [value(1), error(2), end()])
+      expect(log).to.deep.equal([])
+    })
+  })
+
+  describe('watchWithTime', () => {
+    it('should log values emitted by stream', () => {
+      const obs = stream()
+      const {log} = watchWithTime(obs)
+      send(obs, [value(1), error(2), end()])
+      expect(log).to.deep.equal([
+        [0, value(1)],
+        [0, error(2)],
+        [0, end()],
+      ])
+    })
+
+    it('should not log values emitted by stream after unwatch', () => {
+      const obs = stream()
+      const {log, unwatch} = watchWithTime(obs)
+      unwatch()
+      send(obs, [value(1), error(2), end()])
+      expect(log).to.deep.equal([])
     })
   })
 })


### PR DESCRIPTION
Expand the test suite to cover most of the application. Because the
API is pretty exposed at this point, we're not going to test things
like `shakeTimers` fully, as they really should be extracted to a
separate module (or even package? or upstreamed?) and tested
in isolation.

Also return `log` & `unwatch` to `watchWithTime` while maintaining
backwards-compatibility with the normal `log` usage. The API
overall will need to be cleaned up in a future version but this works
well enough.

Fixes #1 & #4.