### PR TITLE
Remove watcher properties

### DIFF
--- a/kefir-test-utils.d.ts
+++ b/kefir-test-utils.d.ts
@@ -31,7 +31,7 @@ export interface Helpers {
   withFakeTime(cb: (tick: (x: number) => void, clock: Clock) => void, reverseSimultaneous?: boolean): void
   logItem<V, E>(event: KEvent<V, E>, current: boolean): Event<V, E>
   watch<V, E>(obs: Observable<V, E>): Watcher<V, E>
-  watchWithTime<V, E>(stream$: Observable<V, E>): EventWithTime<V, E>[] & Watcher<V, E>
+  watchWithTime<V, E>(stream$: Observable<V, E>): EventWithTime<V, E>[]
 }
 
 export interface HelpersFactory {

--- a/kefir-test-utils.test-d.ts
+++ b/kefir-test-utils.test-d.ts
@@ -22,4 +22,4 @@ expectType<void>(
 expectType<Event<string, number>>(logItem({type: 'value', value: 'hello'}, false))
 expectType<Watcher<string, number>>(watch(new Kefir.Stream<string, number>()))
 expectType<EventWithTime<string, any>>([10, value('hello')])
-expectType<EventWithTime<string, number>[] & Watcher<string, number>>(watchWithTime(new Kefir.Stream<string, number>()))
+expectType<EventWithTime<string, number>[]>(watchWithTime(new Kefir.Stream<string, number>()))

--- a/src/index.js
+++ b/src/index.js
@@ -195,15 +195,15 @@ export default function createTestHelpers(Kefir) {
     const log = []
     let isCurrent = true
     const fn = event => log.push([+new Date() - startTime, logItem(event, isCurrent)])
-    const unwatch = () => obs.offAny(fn)
+    // const unwatch = () => obs.offAny(fn)
     obs.onAny(fn)
     isCurrent = false
 
     // Using the array directly is deprecated.
     // Use the log & unwatch properties instead.
     // The return will match `watch` in v2.0.0.
-    log.log = log
-    log.unwatch = unwatch
+    // log.log = log
+    // log.unwatch = unwatch
     return log
   }
 

--- a/test/kefir-test-utils.spec.js
+++ b/test/kefir-test-utils.spec.js
@@ -92,7 +92,7 @@ describe('kefir-test-utils', () => {
       }
 
       withFakeTime(tick => {
-        ;({log} = watchWithTime(obs))
+        log = watchWithTime(obs)
 
         sendFrames(obs, {
           frames: parseDiagram('ab-c--d---#----7-e|---f', events),
@@ -212,7 +212,7 @@ describe('kefir-test-utils', () => {
   describe('watchWithTime', () => {
     it('should log values emitted by stream', () => {
       const obs = stream()
-      const {log} = watchWithTime(obs)
+      const log = watchWithTime(obs)
       send(obs, [value(1), error(2), end()])
       expect(log).to.deep.equal([
         [0, value(1)],
@@ -221,7 +221,7 @@ describe('kefir-test-utils', () => {
       ])
     })
 
-    it('should not log values emitted by stream after unwatch', () => {
+    it.skip('should not log values emitted by stream after unwatch', () => {
       const obs = stream()
       const {log, unwatch} = watchWithTime(obs)
       unwatch()


### PR DESCRIPTION
The extra properties break the matchers.

Reopen #4.