### PR TITLE
Mock Date on test

### DIFF
--- a/test/kefir-test-utils.spec.js
+++ b/test/kefir-test-utils.spec.js
@@ -211,14 +211,16 @@ describe('kefir-test-utils', () => {
 
   describe('watchWithTime', () => {
     it('should log values emitted by stream', () => {
-      const obs = stream()
-      const log = watchWithTime(obs)
-      send(obs, [value(1), error(2), end()])
-      expect(log).to.deep.equal([
-        [0, value(1)],
-        [0, error(2)],
-        [0, end()],
-      ])
+      withFakeTime(() => {
+        const obs = stream()
+        const log = watchWithTime(obs)
+        send(obs, [value(1), error(2), end()])
+        expect(log).to.deep.equal([
+          [0, value(1)],
+          [0, error(2)],
+          [0, end()],
+        ])
+      })
     })
 
     it.skip('should not log values emitted by stream after unwatch', () => {


### PR DESCRIPTION
This test checks that the time difference between the emitted event and
when the observable was activated is 0. However, since `Date` was not
mocked, we couldn't guarantee that.

By wrapping the test execution with `withFakeTime` we are actually
mocking `Date` so we can now guarantee its return value.